### PR TITLE
lib/utf16.c: Clear errno if iconv() sets it to E2BIG

### DIFF
--- a/lib/utf16.c
+++ b/lib/utf16.c
@@ -68,6 +68,7 @@ _hivex_recode (const char *input_encoding, const char *input, size_t input_len,
         errno = err;
         return NULL;
       }
+      errno = 0;
       goto again;
     }
     else {


### PR DESCRIPTION
value_byte_runs() in xml/hivexml.c assumes that
hivex_value_struct_length() failed if it set errno to a nonzero value.
However, _hivex_recode() could internally set errno to nonzero on
success.  This resulted in hivexml failing and printing an error message
like the following:

```
SYSTEM: Argument list too long
```
