### PR TITLE
Increase allocation limit

### DIFF
--- a/lib/hivex-internal.h
+++ b/lib/hivex-internal.h
@@ -341,6 +341,6 @@ extern int _hivex_get_values (hive_h *h, hive_node_h node, hive_value_h **values
 #define HIVEX_MAX_SUBKEYS       70000
 #define HIVEX_MAX_VALUES        55000
 #define HIVEX_MAX_VALUE_LEN   8000000
-#define HIVEX_MAX_ALLOCATION  1000000
+#define HIVEX_MAX_ALLOCATION  8000000
 
 #endif /* HIVEX_INTERNAL_H_ */


### PR DESCRIPTION
Encountered a windows registry where current HIVEX_MAX_ALLOCATION limit (1000000) was not enough